### PR TITLE
Context as a method

### DIFF
--- a/lib/grape/jsonapi/helpers.rb
+++ b/lib/grape/jsonapi/helpers.rb
@@ -23,7 +23,8 @@ module Grape
         )
         ::JSONAPI::RequestParser.new(
           action_parameters,
-          context: {},
+          # define a `context` method to pass extra data to resources
+          context: respond_to?(:context) ? send(:context) : {},
           server_error_callbacks: []
         )
       end


### PR DESCRIPTION
This change gives a way to define own context, thus, it gets passed to a resource.

The idea was to define a `context` method which could be redefined by children. But, it looks like a child's context method gets redefined but the helper method. In general, any method listed in 
 `Grape::JSONAPI::Helpers` cannot be redefined in children.