### PR TITLE
upgrade grape to 1.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     grape-jsonapi (0.0.1)
-      grape (~> 1.2.0)
-      jsonapi-resources (~> 0.9)
+      grape (~> 1.2.5)
+      jsonapi-resources (~> 0.9.10)
 
 GEM
   remote: https://rubygems.org/
@@ -52,7 +52,7 @@ GEM
     docile (1.1.5)
     equalizer (0.0.11)
     erubis (2.7.0)
-    grape (1.2.4)
+    grape (1.2.5)
       activesupport
       builder
       mustermann-grape (~> 1.0.0)

--- a/grape-jsonapi.gemspec
+++ b/grape-jsonapi.gemspec
@@ -17,13 +17,13 @@ Gem::Specification.new do |spec|
                                 .reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ['lib']
 
-  %w(
+  %w[
     bundler otr-activerecord rake rspec rubocop pry-byebug simplecov sqlite3
     rspec-rails json-schema
-  ).each do |gem|
+  ].each do |gem|
     spec.add_development_dependency gem
   end
 
-  spec.add_runtime_dependency 'grape', '~> 1.2.0'
-  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.9'
+  spec.add_runtime_dependency 'grape', '~> 1.2.5'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.9.10'
 end


### PR DESCRIPTION
Unluckily, it didn't happen smoothly.

The `jsonapi-resources` gem was locked on 0.9.x, 0.10.x got lots of changes breaking the integration.